### PR TITLE
Add doc for seleniumServerJar option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,20 @@ gulp.src(["./src/tests/*.js"])
 ```
 
 ### Protractor Webdriver
-You have to update and start a standalone selenium server. [Please read the offical instructions](https://github.com/angular/protractor#appendix-a-setting-up-a-standalone-selenium-server). You can use the build in webdriver snippet. 
+You have to update and start a standalone selenium server. [Please read the offical instructions](https://github.com/angular/protractor#appendix-a-setting-up-a-standalone-selenium-server).  
+You have 2 options to start the selenium server.  
+
+The first one is to let Protractor handle it automatically, including stoping it once your tests are done.  
+To do that, simply point to the selenium jar in the protractor config file (you will need to update the version number accordingly) instead of the address:
+
+```javascript
+  // The file path to the selenium server jar ()
+  seleniumServerJar: './node_modules/protractor/selenium/selenium-server-standalone-2.39.0.jar',
+  // seleniumAddress: 'http://localhost:4444/wd/hub',
+```
+
+The second option is to let the gulp task handle it with the built-in webdriver snippet.  
+If you decide to start it that way, the task will keep running indefintely.
 
 ```javascript
 var webdriver = require("gulp-protractor").webdriver;


### PR DESCRIPTION
This options allows to let Protractor handle the selenium server.  
Unless I'm mistaken, using this option means that the webdriver_start function is not needed in the plugin and the seleniumServerJar option should therefefore be the recommended way to use it.  
The webdriver_update is still needed though.

Let me know if you want me to remove the webdriver_start or if there is a reason to keep it
