### PR TITLE
took out dargs for better control over arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ var protractor = require("gulp-protractor").protractor;
 
 gulp.src(["./src/tests/*.js"])
 	.pipe(protractor({
-		configFile: "test/protractor.config.js"
+		configFile: "test/protractor.config.js",
+    args: ['--baseUrl http://127.0.0.1:8000']
 	}))	
 	.on('error', function(e) { throw e })
 ```
@@ -45,14 +46,6 @@ Type: `Array`
 Default: `[]`
 
 Arguments get passed directly to the protractor call [Read the docs for more information](https://github.com/angular/protractor/blob/master/docs/getting-started.md#setup-and-config)
-
-
-#### options.debug
-Type: `Boolean`  
-Default: `false`
-
-Runs protractor with the debug flag [Protractor Debugging documentation](https://github.com/angular/protractor/blob/master/docs/debugging.md#timeouts)
-
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@ var es = require('event-stream');
 var path = require('path');
 var child_process = require('child_process');
 var async = require('async');
-var dargs = require('dargs');
 var PluginError = require('gulp-util').PluginError;
 var winExt = /^win/.test(process.platform)?".cmd":"";
 
@@ -11,7 +10,7 @@ var protractor = function(options) {
 		child, args;
 
 	options = options || {};
-	args = options.args || {};
+	args = options.args || [];
 
 	if (!options.configFile) {
 		this.emit('error', new PluginError('gulp-protractor', 'Please specify the protractor config file'));
@@ -23,19 +22,11 @@ var protractor = function(options) {
 
 		// Attach Files, if any
 		if (files.length) {
-			args.specs = files.join(',');
+			args.push('--specs ' + files.join(','));
 		}
-
-		// Pass in args
-		args = dargs(args, ['seleniumAddress', 'seleniumServerJar', 'seleniumPort', 'rootElement', 'stackTrace', 'stackTrace']);
 
 		// Pass in the config file
 		args.unshift(options.configFile);
-
-		// Attach debug if we have to
-		if(options.debug) {
-			args.unshift('debug');
-		}
 
 		child = child_process.spawn(path.resolve('./node_modules/.bin/protractor'+winExt), args, {
 			stdio: 'inherit'

--- a/test/main.js
+++ b/test/main.js
@@ -24,9 +24,8 @@ describe('gulp-protactor: protactor', function() {
 
             expect(path.basename(cmd)).to.equal('protractor');
             expect(path.basename(args[0])).to.equal('protactor.config.js');
-            expect(args[1]).to.equal('--browser');
-            expect(args[2]).to.equal('Chrome');
-            expect(args[3]).to.equal('--chrome-only');
+            expect(args[1]).to.equal('--browser Chrome');
+            expect(args[2]).to.equal('--chrome-only');
             child_process.spawn.restore();
             done();
 
@@ -41,45 +40,23 @@ describe('gulp-protactor: protactor', function() {
 
         var stream = protactor({
             configFile: 'test/fixtures/protactor.config.js',
-            args: {
-                browser: 'Chrome',
-                chromeOnly: true
-            }
+            args: [
+                '--browser Chrome',
+                '--chrome-only'
+            ]
         });
 
         stream.write(srcFile);
         stream.end();
     });
 
-
-    it('should pass in debug if debug is true', function(done) {
-        var fakeProcess = new events.EventEmitter();
-        var spy = sinon.stub(child_process, 'spawn', function(cmd, args, options) {
-
-            expect(path.basename(cmd)).to.equal('protractor');
-            expect(path.basename(args[0])).to.equal('debug');
-            expect(path.basename(args[1])).to.equal('protactor.config.js');
-            child_process.spawn.restore();
-            done();
-
-            return new events.EventEmitter();
-        });
-
-        var stream = protactor({
-            configFile: 'test/fixtures/protactor.config.js',
-            debug: true
-        });
-
-        stream.end();
-    });
     it('should pass the test-files to protactor via arg', function(done) {
         var fakeProcess = new events.EventEmitter();
         var spy = sinon.stub(child_process, 'spawn', function(cmd, args, options) {
 
             expect(path.basename(cmd)).to.equal('protractor');
             expect(path.basename(args[0])).to.equal('protactor.config.js');
-            expect(args[1]).to.equal('--specs');
-            expect(args[2]).to.equal('test/fixtures/test.js');
+            expect(args[1]).to.equal('--specs test/fixtures/test.js');
 
             child_process.spawn.restore();
             done();


### PR DESCRIPTION
This addresses issue #6. I was having a problem with this because dargs was mangling 'baseUrl'.

Seems like a better solution would be to let users do their own argument wrangling. If they want to, they can use dargs in their gulp file. 

This seems more flexible than hard-coding dargs to be used all the time.
