### PR TITLE
Fix dependency version matching expressions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,16 +22,16 @@
     "test": "mocha"
   },
   "dependencies": {
-    "event-stream": "~3.1.4",
-    "async": "~0.7.0",
-    "dargs": "~0.1.0",
-    "gulp-util": "~2.2.14",
-    "protractor": "*"
+    "event-stream": "^3.1.4",
+    "async": "0.9.0",
+    "dargs": "0.1.0",
+    "gulp-util": "^3.0.0",
+    "protractor": "^1.0.0"
   },
   "devDependencies": {
-    "mocha": "~1.18.2",
-    "sinon": "~1.9.1",
-    "expect.js": "~0.3.1"
+    "mocha": "^1.18.2",
+    "sinon": "^1.9.1",
+    "expect.js": "0.3.1"
   },
   "engines": {
     "node": ">=0.10.0",


### PR DESCRIPTION
For versions <=0.x.x, use exact matching (ex: async: 0.9.0).
There is no guarantee of compatibility, as
SemVer doesn't apply for versions <=0.x.x.
To guard against breaking dependency changes, use exact matching.

For versions >=1.x.x, use compatible matching (ex: protractor: ^1.0.0).
This example will match <=1.0.0 and <2.x.x.
A major bump reflects a breaking change.

If a dependency is known to be incompatible with SemVer, use exact matching.

http://semver.org/
https://github.com/isaacs/node-semver
