### PR TITLE
Directly resolve protractor's bin dir to support "npm link"

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ function getProtractorDir() {
 	if (result) {
 		// result is now something like 
 		// c:\\Source\\gulp-protractor\\node_modules\\protractor\\lib\\protractor.js
-		protractorDir = path.resolve(path.join(path.dirname(result), "..", "..", ".bin"));
+		protractorDir = path.resolve(path.join(path.dirname(result), "..", "bin"));
 		return protractorDir;
 	}
 	throw new Error("No protractor installation found.");	


### PR DESCRIPTION
If protractor is symlinked via `npm link`, _gulp-protractor_ failed to locate the protractor binary.

That's because `require.resolve(...)` returns the symlinked destination and there's no `../../.bin` from there.