### PR TITLE
Fix for passing arguments to webdriver_update

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ var webdriver_update = function(opts, cb) {
 	if (options) {
 		if (options.browsers) {
 			options.browsers.forEach(function(element, index, array) {
-				args.push("--" + element);
+				args.push(element);
 			});
 		}
 	}	


### PR DESCRIPTION
I use a proxy, and when I pass the opts { browsers: ['proxy http://proxy:8080'] } to webdriver_update, in fact it doesn't use my proxy.
But, if I change the line 80, and pass the opts { browsers: ['--proxy', 'http://proxy:8080'] }, then it works.

Do you think my fix is ok ? Or maybe there is another way ?
