### PR TITLE
Update protractor to 2.x.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ gulp.src(["./src/tests/*.js"])
 	.pipe(protractor({
 		configFile: "test/protractor.config.js",
 		args: ['--baseUrl', 'http://127.0.0.1:8000']
-	}))	
+	}))
 	.on('error', function(e) { throw e })
 ```
 
@@ -35,7 +35,7 @@ To do that, simply point to the selenium jar in the protractor config file (you 
 
 ```javascript
   // The file path to the selenium server jar ()
-  seleniumServerJar: './node_modules/protractor/selenium/selenium-server-standalone-2.44.0.jar',
+  seleniumServerJar: './node_modules/protractor/selenium/selenium-server-standalone-2.45.0.jar',
   // seleniumAddress: 'http://localhost:4444/wd/hub',
 ```
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "async": ">=0.7.0 <1.0.0",
     "dargs": ">=0.1.0 <4.0.0",
     "gulp-util": ">=2.2.14 <4.0.0",
-    "protractor": "^1.0.0"
+    "protractor": "^2.0.0"
   },
   "devDependencies": {
     "mocha": ">=1.18.2 <3.0.0",


### PR DESCRIPTION
Protractor 2.0.0 just came out with one minor breaking change, but gulp-protractor requires version `^1.0.0`. It also updates selenium server version in the readme to the latest one.