### PR TITLE
Use 32-bit IE Driver

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ var protractor = function(options) {
 var webdriver_update = function(opts, cb) {
 	var callback = (cb ? cb : opts);
 	var options = (cb ? opts : null);
-	var args = ["update", "--standalone"];
+	var args = ["update", "--standalone", "--ie32"];
 	if (options) {
 		if (options.browsers) {
 			options.browsers.forEach(function(element, index, array) {


### PR DESCRIPTION
The 64-bit IE driver has been totally broken for over a year now, so
instead download the 32-bit version regardless of the platform
architecture. Note that protractor does not support this argument yet,
it depends on them accepting my pull request #2406