### PR TITLE
Use environment variable to specify protractor location

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var child_process = require('child_process');
 var async = require('async');
 var PluginError = require('gulp-util').PluginError;
 var winExt = /^win/.test(process.platform)?".cmd":"";
+var env = process.env;
 
 // optimization: cache for protractor binaries directory
 var protractorDir = null;
@@ -13,6 +14,14 @@ function getProtractorDir() {
 	if (protractorDir) {
 		return protractorDir;
 	}
+	
+	// Use environment variable PROTRACTOR_DIR
+	// when user needs to use a specific protractor install.
+	if (env.PROTRACTOR_DIR) {
+		protractorDir = env.PROTRACTOR_DIR;
+		return protractorDir;
+	}
+
 	var result = require.resolve("protractor");
 	if (result) {
 		// result is now something like 


### PR DESCRIPTION
Hi,
In some situations, it's useful to be able to specify one protractor install location to use.
For instance, one of my clients prevents any .cmd or .bat file to be executed outside of a specific directory (where global npm packages are installed). Thus, I needed to tell gulp-protractor to use the globally installed protractor.
This PR introduces the PROTRACTOR_DIR environment variable to specify the directory where the protractor and webdriver-manager binaries / wrappers are located.