### PR TITLE
For IE, always use 32-bit driver since 64-bit driver doesn't work.

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,11 @@ var webdriver_update = function(opts, cb) {
 	if (options) {
 		if (options.browsers) {
 			options.browsers.forEach(function(element, index, array) {
-				args.push("--" + element);
+				if (element.toLowerCase() === "ie") {
+					args.push("--ie32");
+				} else {
+					args.push("--" + element);
+				}
 			});
 		}
 	}	


### PR DESCRIPTION
The 64-bit IE driver has been broken for over a year.

Note: this request depends on protractor PR #2406 to be pulled, which it looks like it will