### PR TITLE
Reference protractor bin directory directly

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ function getProtractorDir() {
 	if (result) {
 		// result is now something like 
 		// c:\\Source\\gulp-protractor\\node_modules\\protractor\\lib\\protractor.js
-		protractorDir = path.resolve(path.join(path.dirname(result), "..", "..", ".bin"));
+		protractorDir = path.resolve(path.join(path.dirname(result), "..", "bin"));
 		return protractorDir;
 	}
 	throw new Error("No protractor installation found.");	

--- a/test/main.js
+++ b/test/main.js
@@ -22,7 +22,7 @@ var winExt = /^win/.test(process.platform)?'.cmd':'';
 describe('gulp-protactor: getProtractorDir', function() {
 
     it('should find the protractor installation', function(done) {
-		expect(getProtractorDir()).to.equal(path.resolve('./node_modules/.bin'));
+		expect(getProtractorDir()).to.equal(path.resolve('./node_modules/protractor/bin'));
 		done();
 	});
 });


### PR DESCRIPTION
In the event *npm install* is executed with the *--no-bin-links* option, binary file symbolic links will not be present in *node_modules/.bin*. With or without the *--no-bin-links* option, the binaries will be available in the *node_modules/protractor/bin* directory. This closes issue #79.