### PR TITLE
Revert "Reference protractor bin directory directly"

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ function getProtractorDir() {
 	if (result) {
 		// result is now something like
 		// c:\\Source\\gulp-protractor\\node_modules\\protractor\\lib\\protractor.js
-		protractorDir = path.resolve(path.join(path.dirname(result), "..", "bin"));
+		protractorDir = path.resolve(path.join(path.dirname(result), "..", "..", ".bin"));
 		return protractorDir;
 	}
 	throw new Error("No protractor installation found.");

--- a/test/main.js
+++ b/test/main.js
@@ -22,7 +22,7 @@ var winExt = /^win/.test(process.platform)?'.cmd':'';
 describe('gulp-protactor: getProtractorDir', function() {
 
     it('should find the protractor installation', function(done) {
-		expect(getProtractorDir()).to.equal(path.resolve('./node_modules/protractor/bin'));
+		expect(getProtractorDir()).to.equal(path.resolve('./node_modules/.bin'));
 		done();
 	});
 });


### PR DESCRIPTION
Reverts mllrsohn/gulp-protractor#80

This broke Windows implementation, reverting for now and investigating a better approach.