### PR TITLE
Update deprecated license(s) field

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,9 +43,5 @@
     "node": ">=0.10.0",
     "npm": ">=1.2.10"
   },
-  "licenses": [
-    {
-      "type": "MIT"
-    }
-  ]
+  "license": "MIT"
 }


### PR DESCRIPTION
https://docs.npmjs.com/files/package.json#license

Now when installing:
```
npm info package.json gulp-protractor@2.1.0 No license field.
```