### PR TITLE
Move protractor to peerDependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .DS_Store
 node_modules/
 temp/
+
+.idea/
+*.iml

--- a/package.json
+++ b/package.json
@@ -31,8 +31,10 @@
     "async": "~1.5.0",
     "dargs": "~4.0.1",
     "event-stream": "~3.3.0",
-    "gulp-util": ">=2.2.14 <4.0.0",
-    "protractor": "~3.0.0"
+    "gulp-util": ">=2.2.14 <4.0.0"
+  },
+  "peerDependencies": {
+    "protractor": ">=3.0.0 <4.0.0"
   },
   "devDependencies": {
     "mocha": ">=1.18.2 <3.0.0",


### PR DESCRIPTION
Looks like the way it's now Protractor version is locked to 3.0.x. I experienced some issues on my project that got resolved by 3.1.1 version. When I tried to install 3.1.1, NPM installed 3.0.0 into nested `gulp-protractor/node_modules`, and paths to webdriver / selenium got broken as well.

Moving Protractor to peerDependencies will resolve this hard dependency.
