### PR TITLE
Allow webdriver manager options to be passed in via the "opts" argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,6 +76,11 @@ var webdriver_update = function(opts, cb) {
   var options = (cb ? opts : null);
   var args = ["update", "--standalone"];
   if (options) {
+	if (options.webdriverManagerArgs) {
+		options.webdriverManagerArgs.forEach(function(element) {
+			args.push(element);
+		});
+	}
     if (options.browsers) {
       options.browsers.forEach(function(element, index, array) {
         args.push("--" + element);


### PR DESCRIPTION
Allow webdriver manager options to be passed in via the "opts" argument.  All arguments passed in through the "opts.webdriverManagerArgs" array will be appended as arguments.  This allows you to set the proxy and anything else that might come along one day.
