### PR TITLE
Add autoStartStop option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ var protractor = require("gulp-protractor").protractor;
 
 gulp.src(["./src/tests/*.js"])
 	.pipe(protractor({
+                // autoStartStop: true,
 		configFile: "test/protractor.config.js",
 		args: ['--baseUrl', 'http://127.0.0.1:8000']
 	}))
@@ -24,13 +25,15 @@ gulp.src(["./src/tests/*.js"])
 ```
 
 ### Protractor Webdriver
-You have to update and start a standalone selenium server. [Please read the offical instructions](https://github.com/angular/protractor#appendix-a-setting-up-a-standalone-selenium-server).
+You may have to update and start a standalone selenium server depending on your configuration. [Please read the offical instructions](https://github.com/angular/protractor#appendix-a-setting-up-a-standalone-selenium-server).
 
 You can also ensure that the driver is installed by using the `webdriver_update` task. Have a look at the example folder.
 
-You have 2 options to start the selenium server.
+You have 3 options to start the selenium server.
 
-The first one is to let Protractor handle it automatically, including stopping it once your tests are done.
+The first, and easiest option is to use the `autoStartStop` configuration option highlighted in the example above. It will update and start the latest version of webdriver.
+
+The second one is to let Protractor handle it automatically, including stopping it once your tests are done.
 To do that, simply point to the selenium jar in the protractor config file (you will need to update the version number accordingly) instead of the address:
 
 ```javascript
@@ -39,7 +42,7 @@ To do that, simply point to the selenium jar in the protractor config file (you 
   // seleniumAddress: 'http://localhost:4444/wd/hub',
 ```
 
-The second option is to let the gulp task handle it with the built-in webdriver snippet.
+The third option is to let the gulp task handle it with the built-in webdriver snippet.
 If you decide to start it that way, the task will keep running indefinitely.
 
 ```javascript
@@ -69,6 +72,11 @@ Default: `false`
 
 Enables Protractor's [debug mode](https://github.com/angular/protractor/blob/master/docs/debugging.md), which can be used to pause tests during execution and to view stack traces.
 
+#### options.autoStartStop
+Type: `Boolean`
+Default: `false`
+
+Automatically download the latest webdriver, start it before Protractor, and kill it when Protractor completes.
 
 # Running Protractor without a plugin
 If you want to avoid using a plugin at all, here are gulp tasks which install the webdriver and start protractor:

--- a/index.js
+++ b/index.js
@@ -4,36 +4,35 @@ var path = require('path');
 var child_process = require('child_process');
 var async = require('async');
 var PluginError = require('gulp-util').PluginError;
-var winExt = /^win/.test(process.platform)?".cmd":"";
+var winExt = /^win/.test(process.platform)?'.cmd':'';
 
 // optimization: cache for protractor binaries directory
-var protractorDir = null;
+var binDir = null;
 
-function getProtractorDir() {
-  if (protractorDir) {
-    return protractorDir;
-  }
-  var result = require.resolve("protractor");
+function getBinDir() {
+  if (binDir) return binDir;
+  var result = require.resolve('protractor');
   if (result) {
     // result is now something like
     // c:\\Source\\gulp-protractor\\node_modules\\protractor\\lib\\protractor.js
-    protractorDir = path.resolve(path.join(path.dirname(result), "..", "..", ".bin"));
-    return protractorDir;
+    return path.resolve(path.join(path.dirname(result), '..', '..', '.bin'));
   }
-  throw new Error("No protractor installation found.");
+  throw new Error('No protractor installation found.');
 }
 
-var protractor = function(options) {
+function protractor(options) {
   var files = [],
-    child, args;
+      args;
 
   options = options || {};
   args = options.args || [];
 
-  return es.through(function(file) {
+  function write(file) {
     files.push(file.path);
     this.push(file);
-  }, function() {
+  }
+
+  function end() {
     var stream = this;
 
     // Enable debug mode
@@ -52,55 +51,76 @@ var protractor = function(options) {
       args.unshift(options.configFile);
     }
 
-    child = child_process.spawn(path.resolve(getProtractorDir() + '/protractor'+winExt), args, {
-      stdio: 'inherit',
-      env: process.env
-    }).on('exit', function(code) {
-      if (child) {
-        child.kill();
-      }
-      if (stream) {
-        if (code) {
-          stream.emit('error', new PluginError('gulp-protractor', 'protractor exited with code ' + code));
-        }
-        else {
-          stream.emit('end');
-        }
-      }
-    });
-  });
+    if (options.autoStartStop) {
+      webdriver_update(null, function() {
+        args.push('--seleniumServerJar', getSeleniumJarPath());
+        spawnProtractor(args, stream);
+      });
+    } else {
+      spawnProtractor(args, stream);
+    }
+  }
+  return es.through(write, end);
 };
 
-var webdriver_update = function(opts, cb) {
+function spawnProtractor(args, stream) {
+  var child = child_process.spawn(path.resolve(getBinDir() + '/protractor'+winExt), args, {
+    stdio: 'inherit',
+    env: process.env
+  }).on('exit', function(code) {
+    if (child) child.kill();
+    if (stream) {
+      if (code) {
+        stream.emit('error', new PluginError('gulp-protractor', 'protractor exited with code ' + code));
+      }
+      else {
+        stream.emit('end');
+      }
+    }
+  });
+}
+
+function webdriver_update(opts, cb) {
   var callback = (cb ? cb : opts);
   var options = (cb ? opts : null);
-  var args = ["update", "--standalone"];
+  var args = ['update', '--standalone'];
   if (options) {
     if (options.browsers) {
       options.browsers.forEach(function(element, index, array) {
-        args.push("--" + element);
+        args.push('--' + element);
       });
     }
   }
-  child_process.spawn(path.resolve(getProtractorDir() + '/webdriver-manager'+winExt), args, {
+  child_process.spawn(path.resolve(getBinDir() + '/webdriver-manager'+winExt), args, {
     stdio: 'inherit'
   }).once('close', callback);
 };
 
-var webdriver_update_specific = function(opts) {
+function webdriver_update_specific(opts) {
   return webdriver_update.bind(this, opts);
 };
 
-webdriver_update.bind(null, ["ie", "chrome"])
+webdriver_update.bind(null, ['ie', 'chrome'])
 
-var webdriver_standalone = function(cb) {
-  var child = child_process.spawn(path.resolve(getProtractorDir() + '/webdriver-manager'+winExt), ['start'], {
+function webdriver_standalone(cb) {
+  var webdriverManager = child_process.spawn(path.resolve(getBinDir() + '/webdriver-manager'+winExt), ['start'], {
     stdio: 'inherit'
-  }).once('close', cb);
+  });
+  webdriverManager.once('close', cb);
+  return webdriverManager;
 };
 
+function getSeleniumJarPath() {
+  var seleniumDir = path.resolve(path.join(getBinDir(), '..', 'protractor', 'selenium'));
+  var files = fs.readdirSync(seleniumDir)
+  var seleniumJar = files.find(function(file) {
+    return file.match(/^selenium-server.*\.jar$/);
+  });
+  return path.join(seleniumDir, seleniumJar);
+}
+
 module.exports = {
-  getProtractorDir: getProtractorDir,
+  getProtractorDir: getBinDir,
   protractor: protractor,
   webdriver_standalone: webdriver_standalone,
   webdriver_update: webdriver_update,


### PR DESCRIPTION
Adds support to automatically download, start, and stop the latest Selenium standalone using Protractor's `webdriver-manager`. This will only work with the latest version specified by Protractor.
