### PR TITLE
Return child process and add optional options to webdriver_standalone.

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ var webdriver_update_specific = function(opts) {
 webdriver_update.bind(null, ["ie", "chrome"])
 
 var webdriver_standalone = function(cb) {
-  var child = child_process.spawn(path.resolve(getProtractorDir() + '/webdriver-manager'+winExt), ['start'], {
+  return child = child_process.spawn(path.resolve(getProtractorDir() + '/webdriver-manager'+winExt), ['start'], {
     stdio: 'inherit'
   }).once('close', cb);
 };

--- a/index.js
+++ b/index.js
@@ -93,10 +93,11 @@ var webdriver_update_specific = function(opts) {
 
 webdriver_update.bind(null, ["ie", "chrome"])
 
-var webdriver_standalone = function(cb) {
-  return child = child_process.spawn(path.resolve(getProtractorDir() + '/webdriver-manager'+winExt), ['start'], {
-    stdio: 'inherit'
-  }).once('close', cb);
+var webdriver_standalone = function(opts, cb) {
+  var callback = (cb ? cb : opts);
+  var options = (cb ? opts : {});
+  return child = child_process.spawn(path.resolve(getProtractorDir() + '/webdriver-manager'+winExt), ['start'], options
+  ).once('close', cb);
 };
 
 module.exports = {


### PR DESCRIPTION
I've used the following changes to make the webdriver_standalone function a lot more useful.

Node's child_process can't kill children process in an easy way. I found it a lot easier to just pipe 'q' to the webdriver's stdin.

My gulp task contains the following:
```
var webdriverServer = webdriver_standalone({stdio: ['pipe', 1, 2]}, () => {});
// Run tests
webdriverServer.stdin.write('q\n');
```