### PR TITLE
Listen for 'close' event rather than 'exit'

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ var protractor = function(options) {
     child = child_process.spawn(path.resolve(getProtractorDir() + '/protractor'+winExt), args, {
       stdio: 'inherit',
       env: process.env
-    }).on('exit', function(code) {
+    }).on('close', function(code) {
       if (child) {
         child.kill();
       }

--- a/test/main.js
+++ b/test/main.js
@@ -126,7 +126,7 @@ describe('gulp-protractor: protractor', function() {
     var fakeProcess = new events.EventEmitter();
     var spy = sinon.stub(child_process, 'spawn', function(cmd, args, options) {
       child_process.spawn.restore();
-      process.nextTick(function() { fakeProcess.emit('exit', 255) });
+      process.nextTick(function() { fakeProcess.emit('close', 255) });
       fakeProcess.kill = function() {};
       return fakeProcess;
     });


### PR DESCRIPTION
We were experiencing an issue whereby failing tests would sometimes not result in an error exit code and hence related CI builds would pass despite the failing tests.

This change seems to fix the issue for us. I couldn't find any documentation on the `exit` event but I'm pretty sure the correct event to listen for here is `close` - unless there's a specific reason to use `exit`?
