### PR TITLE
Fix unhandled Out Of Memory error.

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,13 +67,14 @@ var protractor = function(options) {
 		child = childProcess.fork(getProtractorCli(), args, {
 			stdio: 'inherit',
 			env: process.env
-		}).on('exit', function(code) {
+		}).on('exit', function(code, signal) {
 			if (child) {
 				child.kill();
 			}
 			if (stream) {
-				if (code) {
-					stream.emit('error', new PluginError('gulp-protractor', 'protractor exited with code ' + code));
+				if (code !== 0) {
+					var errorMessage = 'protractor exited with code ' + code + ' and signal ' + signal
+					stream.emit('error', new PluginError('gulp-protractor', errorMessage));
 				} else {
 					stream.emit('end');
 				}


### PR DESCRIPTION
First of all thank you for your plugin, it's been years that we use it.

We recently met an issue on our CI servers, where our test phase ends in success while protractor breaks due to an Out Of Memory error.
This is because the error code received in the plugin is null instead of being a positive integer, so the plugin exits like everything is ok when this happens, however we can see that the received signal is well 'SIGABRT'.

So I propose to exit with an error if the received code is strictly different from 0.

A post on stackoverflow where someone explain about the exit with a code null:
https://stackoverflow.com/questions/39159312/child-process-exits-with-code-null

And an example of what the value code and signal are when an Out Of Memory error happens.
```
<--- JS stacktrace --->

==== JS stack trace =========================================

Security context: 0x2feb5f925879 <JSObject>
    1: SparseJoinWithSeparatorJS(aka SparseJoinWithSeparatorJS) [native array.js:~43] [pc=0x3a8fe6879c12](this=0x37381f8022d1 <undefined>,o=0x24b5775d8e49 <JSArray[25244]>,v=0x17b3bc631b41 <JSArray[25244]>,p=25244,y=0x37381f8023e1 <false>,z=0x229b60f11ba9 <String[1]\: \n>)
    2: DoJoin(aka DoJoin) [native array.js:~94] [pc=0x3a8fe68771e9](this=0x37381f8022d1 <undefined>,o=0x24b5775d8e49 <JSArra...

FATAL ERROR: CALL_AND_RETRY_LAST Allocation failed - JavaScript heap out of memory
 1: node::Abort() [/usr/local/bin/node]
 2: 0x8cbf4c [/usr/local/bin/node]
 3: v8::Utils::ReportOOMFailure(char const*, bool) [/usr/local/bin/node]
 4: v8::internal::V8::FatalProcessOutOfMemory(char const*, bool) [/usr/local/bin/node]
 5: v8::internal::Factory::NewRawTwoByteString(int, v8::internal::PretenureFlag) [/usr/local/bin/node]
 6: v8::internal::Runtime_SparseJoinWithSeparator(int, v8::internal::Object**, v8::internal::Isolate*) [/usr/local/bin/node]
 7: 0x3a8fe67042fd
code null
signal SIGABRT
```