### PR TITLE
Excluding unnecessary files from npm packaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,5 +52,10 @@
     "node": ">=4.2.0",
     "npm": ">=1.2.10"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "files": [
+	"README.md",
+	"LICENSE",
+	"index.js"
+  ]
 }


### PR DESCRIPTION
Adding "files" section to package.json to exclude examples and tests from npm packaging.